### PR TITLE
add RELEASE_CHANNEL variable to let the user pick which channel to us…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ env:
     # This will be part of the release tarball
     # TODO change the project name
     - PROJECT_NAME=rust-everywhere
+    # Channel used to build binary artifacts for release
+    # TODO you may want to pick a different channel
+    - RELEASE_CHANNEL=beta
 
 # AFAICT There are a few ways to set up the build jobs. This one is not the DRYest but I feel is the
 # easiest to reason about.
@@ -136,7 +139,7 @@ deploy:
   on:
     # only release on the stable channel
     # NOTE make sure you only release *once* per target
-    condition: $TRAVIS_RUST_VERSION = stable
+    condition: $TRAVIS_RUST_VERSION = $RELEASE_CHANNEL
     tags: true
 
 branches:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,6 @@ version = "0.1.34"
 [[bin]]
 name = "hello"
 path = "src/main.rs"
+
+[build-dependencies]
+rustc_version = "0.1.7"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,9 @@ environment:
     # This will be used as part of the zipfile name
     # TODO change the project name
     PROJECT_NAME: rust-everywhere
+    # Channel used to build binary artifacts for release
+    # TODO you may want to pick a different channel
+    RELEASE_CHANNEL: beta
   # TODO feel free to delete targets/channels you don't need
   matrix:
     # Stable channel
@@ -61,10 +64,10 @@ test_script:
   - cargo build --verbose
   - cargo run
   - cargo test
-  - cargo build --release
 
-# Equivalent to `before_deploy` phase
-after_test:
+before_deploy:
+  # Generate artifacts for release
+  - cargo build --release
   - mkdir staging
   # TODO update this part to copy the artifacts that make sense for your project
   - copy target\release\hello.exe staging
@@ -92,7 +95,7 @@ deploy:
   provider: GitHub
   # deploy when a new tag is pushed and only on the stable channel
   on:
-    RUST_CHANNEL: stable
+    RUST_CHANNEL: $RELEASE_CHANNEL
     appveyor_repo_tag: true
 
 branches:

--- a/build.rs
+++ b/build.rs
@@ -1,13 +1,19 @@
 #![deny(warnings)]
 
+extern crate rustc_version;
+
 use std::env;
 use std::fs::File;
 use std::io::Write;
 
 fn hello() -> String {
-    format!("fn main() {{ println!(\"{}: {} says hello!\") }}\n#[test] fn ok() {{ assert!(true) }}",
+    let meta = rustc_version::version_meta();
+
+    format!("fn main() {{ println!(\"{}: {} says hello!\nCompiled with rust-{} ({:?} channel)\") }}\n#[test] fn ok() {{ assert!(true) }}",
             env::var("CARGO_PKG_VERSION").unwrap(),
-            env::var("TARGET").unwrap())
+            env::var("TARGET").unwrap(),
+            meta.semver,
+            meta.channel)
 }
 
 fn main() {

--- a/ci/before_deploy.sh
+++ b/ci/before_deploy.sh
@@ -2,6 +2,9 @@
 
 set -ex
 
+# Generate artifacts for release
+cargo build --release
+
 # create a "staging" directory
 mkdir staging
 

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -30,7 +30,5 @@ case $TARGET in
     ;;
 esac
 
-cargo build --target $TARGET --release
-
 # sanity check the file type
-file target/$TARGET/release/hello
+file target/$TARGET/debug/hello


### PR DESCRIPTION
…e for releases

release artifacts are only generated on $RELEASE_CHANNEL and only when a deployment is due.

The `hello` app nows print the rust version/channel it was compiled with; to aid debugging.
