### PR TITLE
disable doc tests when cross compiling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -111,13 +111,13 @@ matrix:
       rust: nightly
 
 install:
-  - sh ci/install.sh
+  - bash ci/install.sh
 
 script:
-  - sh ci/script.sh
+  - bash ci/script.sh
 
 before_deploy:
-  - sh ci/before_deploy.sh
+  - bash ci/before_deploy.sh
 
 deploy:
   provider: releases

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -7,6 +7,20 @@ set -ex
 # to target/$TARGET/{debug,release} which can reduce the number of needed conditionals in the
 # `before_deploy`/packaging phase
 
+case "$TRAVIS_OS_NAME" in
+  linux)
+    host=x86_64-unknown-linux-gnu
+    ;;
+  osx)
+    host=x86_64-unknown-linux-gnu
+    ;;
+esac
+
+# NOTE Workaround for rust-lang/rust#31907 - disable doc tests when cross compiling
+if [ "$host" != "$target" ]; then
+  sed -i 's:\(//.\s*```\):\1 ignore,:g' src/**/*.rs
+fi
+
 case $TARGET in
   # use an emulator to run the cross compiled binaries
   arm-unknown-linux-gnueabihf)

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -19,7 +19,7 @@ esac
 # NOTE Workaround for rust-lang/rust#31907 - disable doc tests when cross compiling
 if [ "$host" != "$TARGET" ]; then
   if [ "$TRAVIS_OS_NAME" = "osx" ]; then
-    brew install gnu-sed --with-default-names
+    brew install gnu-sed --default-names
   fi
 
   find src -name '*.rs' -type f | xargs sed -i -e 's:\(//.\s*```\):\1 ignore,:g'

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -10,15 +10,17 @@ set -ex
 case "$TRAVIS_OS_NAME" in
   linux)
     host=x86_64-unknown-linux-gnu
+    sedi="sed -i"
     ;;
   osx)
     host=x86_64-apple-darwin
+    sedi="sed -i ''"
     ;;
 esac
 
 # NOTE Workaround for rust-lang/rust#31907 - disable doc tests when cross compiling
 if [ "$host" != "$TARGET" ]; then
-  find src -name '*.rs' -type f | xargs sed -i -e 's:\(//.\s*```\):\1 ignore,:g'
+  find src -name '*.rs' -type f | xargs $sedi -e 's:\(//.\s*```\):\1 ignore,:g'
 fi
 
 case $TARGET in

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -1,6 +1,7 @@
 # `script` phase: you usually build, test and generate docs in this phase
 
 set -ex
+shopt -s globstar
 
 # TODO modify this phase as you see fit
 # PROTIP Always pass `--target $TARGET` to cargo commands, this makes cargo output build artifacts

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -18,7 +18,7 @@ esac
 
 # NOTE Workaround for rust-lang/rust#31907 - disable doc tests when cross compiling
 if [ "$host" != "$TARGET" ]; then
-  find src -name '*.rs' -type f | xargs sed -i 's:\(//.\s*```\):\1 ignore,:g'
+  find src -name '*.rs' -type f | xargs sed -i -e 's:\(//.\s*```\):\1 ignore,:g'
 fi
 
 case $TARGET in

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -10,17 +10,19 @@ set -ex
 case "$TRAVIS_OS_NAME" in
   linux)
     host=x86_64-unknown-linux-gnu
-    sedi="sed -i"
     ;;
   osx)
     host=x86_64-apple-darwin
-    sedi="sed -i ''"
     ;;
 esac
 
 # NOTE Workaround for rust-lang/rust#31907 - disable doc tests when cross compiling
 if [ "$host" != "$TARGET" ]; then
-  find src -name '*.rs' -type f | xargs $sedi -e 's:\(//.\s*```\):\1 ignore,:g'
+  if [ "$TRAVIS_OS_NAME" = "osx" ]; then
+    brew install gnu-sed --with-default-names
+  fi
+
+  find src -name '*.rs' -type f | xargs sed -i -e 's:\(//.\s*```\):\1 ignore,:g'
 fi
 
 case $TARGET in

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -12,7 +12,7 @@ case "$TRAVIS_OS_NAME" in
     host=x86_64-unknown-linux-gnu
     ;;
   osx)
-    host=x86_64-unknown-linux-gnu
+    host=x86_64-apple-darwin
     ;;
 esac
 

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -17,7 +17,7 @@ case "$TRAVIS_OS_NAME" in
 esac
 
 # NOTE Workaround for rust-lang/rust#31907 - disable doc tests when cross compiling
-if [ "$host" != "$target" ]; then
+if [ "$host" != "$TARGET" ]; then
   sed -i 's:\(//.\s*```\):\1 ignore,:g' src/**/*.rs
 fi
 

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -1,7 +1,6 @@
 # `script` phase: you usually build, test and generate docs in this phase
 
 set -ex
-shopt -s globstar
 
 # TODO modify this phase as you see fit
 # PROTIP Always pass `--target $TARGET` to cargo commands, this makes cargo output build artifacts
@@ -19,7 +18,7 @@ esac
 
 # NOTE Workaround for rust-lang/rust#31907 - disable doc tests when cross compiling
 if [ "$host" != "$TARGET" ]; then
-  sed -i 's:\(//.\s*```\):\1 ignore,:g' src/**/*.rs
+  find src -name '*.rs' -type f | xargs sed -i 's:\(//.\s*```\):\1 ignore,:g'
 fi
 
 case $TARGET in

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,5 @@
+//! ```
+//! extern crate rust_everywhere;
+//!
+//! assert!(true);
+//! ```


### PR DESCRIPTION
workaround for rust-lang/rust#31907
