### PR TITLE
travis/linux/arm: run *all* tests under the emulator

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -32,8 +32,8 @@ case $TARGET in
     cargo test --target $TARGET --no-run
 
     # run tests in emulator
-    find target/$TARGET/debug -maxdepth 1 -executable -type f | \
-      xargs qemu-arm -L /usr/arm-linux-gnueabihf
+    find target/$TARGET/debug -maxdepth 1 -executable -type f \
+      -exec qemu-arm -L /usr/arm-linux-gnueabihf '{}' ';'
 
     # build the main executable
     cargo build --target $TARGET


### PR DESCRIPTION
The previous code was calling `qemu-arm -L (..) $test1 $test2 $test3` which only executes the first
test. The new code calls `qemu-arm -L (..)` on each test binary.
