### PR TITLE
the 32-bit musl target is now available on stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -147,13 +147,12 @@ matrix:
       rust: nightly
       env: TARGET=x86_64-unknown-linux-musl
   allow_failures:
-    # Target `i686-unknown-linux-musl` is currently only available on the nightly channel
-    - os: linux
-      rust: stable
-      env: TARGET=i686-unknown-linux-musl
-    - os: linux
-      rust: beta
-      env: TARGET=i686-unknown-linux-musl
+    # TODO You might need to allow failures for some target on some channel for some reason. Below
+    # there's one (commented out) example of how to do that. Just change the OS, channel and TARGET
+    # as needed.
+    # - os: linux
+    #   rust: stable
+    #   env: TARGET=x86_64-unknown-linux-gnu
 
 before_install:
   - export PATH="$PATH:$HOME/.cargo/bin"


### PR DESCRIPTION
also leave an example of how to allow the failure of a build job.

closes #44
