### PR TITLE
Add branches.only tag regex to appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -88,3 +88,6 @@ deploy:
 branches:
   only:
     - master
+    # IMPORTANT Regex to match tags. Required, or appveyor may not trigger deploys when a new tag
+    # is pushed. This regex matches semantic versions like v1.2.3-rc4+2016.02.22
+    - /^v\d+\.\d+\.\d+.*$/


### PR DESCRIPTION
Wish I'd found the linked issue before my own 30 mins of flailing :)

I actually found that even lightweight tags were unreliable until I added this.

Fixes #52